### PR TITLE
Patch python library location and sbin files for EL7.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ INSTALL_FILES=vcycled shared.py vacutils.py __init__.py \
 TGZ_FILES=$(INSTALL_FILES) Makefile vcycle.spec
 
 GNUTAR ?= tar
+
+PYTHONDIR := $(shell python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+
 vcycle.tgz: $(TGZ_FILES)
 	mkdir -p TEMPDIR/vcycle
 	cp $(TGZ_FILES) TEMPDIR/vcycle
@@ -51,7 +54,7 @@ vcycle.tgz: $(TGZ_FILES)
 
 install: $(INSTALL_FILES)
 	mkdir -p $(RPM_BUILD_ROOT)/usr/sbin \
- 	         $(RPM_BUILD_ROOT)/usr/lib64/python2.6/site-packages/vcycle \
+	         $(RPM_BUILD_ROOT)$(PYTHONDIR)/vcycle \
  	         $(RPM_BUILD_ROOT)/usr/share/doc/vcycle-$(VERSION) \
  	         $(RPM_BUILD_ROOT)/usr/share/man/man5 \
                  $(RPM_BUILD_ROOT)/usr/share/man/man8 \
@@ -71,7 +74,7 @@ install: $(INSTALL_FILES)
 	cp __init__.py shared.py vacutils.py \
 	   openstack_api.py occi_api.py \
 	   dbce_api.py azure_api.py ec2_api.py \
-	   $(RPM_BUILD_ROOT)/usr/lib64/python2.6/site-packages/vcycle
+	   $(RPM_BUILD_ROOT)$(PYTHONDIR)/vcycle
 	cp VERSION CHANGES vcycle.httpd.conf vcycle.httpd.inc \
 	   example.vcycle.conf vcycle.conf.5 vcycled.8 \
 	   admin-guide.html \

--- a/vcycle.spec
+++ b/vcycle.spec
@@ -58,13 +58,13 @@ if [ $? = 0 ] ; then
 fi
 
 %files
-/usr/sbin
+/usr/sbin/*
 /usr/share/doc/vcycle-%{version}
-/usr/lib64/python2.6/site-packages/vcycle/__init__.py*
-/usr/lib64/python2.6/site-packages/vcycle/shared.py*
-/usr/lib64/python2.6/site-packages/vcycle/vacutils.py*
-/usr/lib64/python2.6/site-packages/vcycle/openstack_api.py*
-/usr/lib64/python2.6/site-packages/vcycle/ec2_api.py*
+%{python_sitelib}/vcycle/__init__.py*
+%{python_sitelib}/vcycle/shared.py*
+%{python_sitelib}/vcycle/vacutils.py*
+%{python_sitelib}/vcycle/openstack_api.py*
+%{python_sitelib}/vcycle/ec2_api.py*
 /var/lib/vcycle
 /etc/rc.d/init.d/vcycled
 /etc/logrotate.d/vcycled
@@ -76,10 +76,10 @@ fi
 pip install azure-servicemanagement-legacy
 
 %files azure
-/usr/lib64/python2.6/site-packages/vcycle/azure_api.py* 
+%{python_sitelib}/vcycle/azure_api.py*
 
 %files occi
-/usr/lib64/python2.6/site-packages/vcycle/occi_api.py* 
+%{python_sitelib}/vcycle/occi_api.py*
 
 %files dbce
-/usr/lib64/python2.6/site-packages/vcycle/dbce_api.py*
+%{python_sitelib}/vcycle/dbce_api.py*


### PR DESCRIPTION
Hi Andrew,

This is a patch to allow vcycle to be built on EL7 (particularly packaged as an RPM). I've tested the patch on CentOS6 & 7 and it seems to work for both.

Regards,
Simon
